### PR TITLE
Fix logic for opening WelcomePopup on first visit

### DIFF
--- a/components/theme-switcher/WelcomePopup.vue
+++ b/components/theme-switcher/WelcomePopup.vue
@@ -30,7 +30,7 @@ onMounted(() => {
   const hasVisited = localStorage.getItem('hasVisited')
   if (!hasVisited) {
     localStorage.setItem('hasVisited', 'true')
+    isOpen.value = true
   }
-  isOpen.value = true
 })
 </script>


### PR DESCRIPTION
Correct the condition to ensure the WelcomePopup opens only on the user's first visit.